### PR TITLE
Refactor : 결제 중 동시성 처리 부 구분 및 명시 추가 

### DIFF
--- a/post/src/main/java/org/example/controller/PostController.java
+++ b/post/src/main/java/org/example/controller/PostController.java
@@ -9,6 +9,7 @@ import org.example.dto.purchase.PaymentsReq;
 import org.example.dto.purchase.PurchaseDto;
 import org.example.dto.purchase.SellDto;
 import org.example.dto.search.SearchDto;
+import org.example.exception.OutOfStockByXLockException;
 import org.example.service.MailService;
 import org.example.service.SearchService;
 import org.example.service.WishListService;
@@ -89,7 +90,7 @@ public class PostController {
     }
 
     @PostMapping("/payments/sell")
-    public PurchaseDto changeState(@RequestBody SellDto sellDto){
+    public PurchaseDto changeState(@RequestBody SellDto sellDto) throws OutOfStockByXLockException {
         int soldOut = wishListService.sellWishList(sellDto.getPost_id(),sellDto.getEmail());
         if (soldOut==0){
             wishListService.successPay(sellDto.getPost_id());

--- a/post/src/main/java/org/example/exception/OutOfStockByXLockException.java
+++ b/post/src/main/java/org/example/exception/OutOfStockByXLockException.java
@@ -1,0 +1,14 @@
+package org.example.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+public class OutOfStockByXLockException extends Throwable {
+    private String message;
+}

--- a/post/src/main/java/org/example/service/PostService.java
+++ b/post/src/main/java/org/example/service/PostService.java
@@ -7,6 +7,7 @@ import org.example.dto.post.*;
 import org.example.dto.wish_list.EmailDto;
 import org.example.entity.Post;
 import org.example.entity.WishList;
+import org.example.exception.OutOfStockByXLockException;
 import org.example.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -198,9 +199,14 @@ public class PostService {
     }
 
     @Transactional
-    public void changeState(List<Long> postIds){
+    public void changeState(List<Long> postIds) throws OutOfStockByXLockException {
         for (Long postId : postIds){
             Post post = postRepository.findByPostIdWithLock(postId);
+            if(post.getTotalNumber() <=0 )
+            {
+                throw new OutOfStockByXLockException("상품 Id : " + postId+ " 재고 부족(동시 접근)");
+            }
+
             if(post.getTotalNumber()-1>0){ postRepository.updateTotalNumber(post.getTotalNumber()-1,postId);}
             else{
                 postRepository.updateTotalNumber(0,postId);

--- a/post/src/main/java/org/example/service/PostService.java
+++ b/post/src/main/java/org/example/service/PostService.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.util.*;
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class PostService {
 
     private final PostRepository postRepository ;
@@ -204,6 +205,7 @@ public class PostService {
             Post post = postRepository.findByPostIdWithLock(postId);
             if(post.getTotalNumber() <=0 )
             {
+                log.error("재고 부족 발생 - PostId: {}, 현재 재고: {}", postId, post.getTotalNumber());
                 throw new OutOfStockByXLockException("상품 Id : " + postId+ " 재고 부족(동시 접근)");
             }
 

--- a/purchase/src/main/java/org/example/service/PaymentService.java
+++ b/purchase/src/main/java/org/example/service/PaymentService.java
@@ -12,6 +12,7 @@ import org.example.dto.forbackend.PurchaseDto;
 import org.example.dto.portone.*;
 import org.example.entity.Payment;
 import org.example.repository.PaymentRepository;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
@@ -37,11 +38,14 @@ public class PaymentService {
 
     private final PaymentRepository paymentRepository;
 
+    @Value("${}")
+    private String portoneKey;
+
 
     //portone에서 결제 조회를 하려면, portonetoken이 필요합니다. 해당 token을 가져오는부 입니다.
     //사이트 내부적으로 너무 빨리 갱신하여, 매번 가져오는 형태로 변경하였습니다.
     public Mono<String> getPortOneToken() {
-        PortoneTokenRequest portoneTokenRequest = new PortoneTokenRequest("hM546ISQZ7vQ61xw0eTV0hk7GpRDS48Pr92uTBGbCc5z9u4iSC3DiMed3SHBohBQHWj8ZEPHJF6J8VNA");
+        PortoneTokenRequest portoneTokenRequest = new PortoneTokenRequest(portoneKey);
 
         Mono<String> PortOneToken;
 


### PR DESCRIPTION
#개인 기록을 위한 부

결제 중 동시성 처리 부를 기존 처리했던 것은,
1. Update 부(판매 후 상태 관리) + 예약 가능 수 check>=0 (db의 제약조건)
2. sql exception -> feign exception -> webclientexception 으로 자동 전파 되는 현상 이용
이었습니다. 

허나 해당 방식은 결제 취소 처리는 (예외 처리) 잘 이루어지나, **중간의 member , post 마이크로 서비스 들에서는 exception 처리가 이어지지 않았다는 문제를 발견했습니다.**

이를 처리하기 위해 Post 마이크로서비스에서 customexception을 추가하고, 이를 전달받는 member 서비스에서 로그를 추가했습니다.

또한 발생할 수 있는 동시성 문제 case 들인
1. 상품 결제 중 강사가 판매 완료로 수정,
2. 동일 상품 동시 결제 중, 판매 제약 수 넘음 

두가지 케이스들을 분리하여 로깅을 진행하였습니다.