### PR TITLE
Refactor: 결제 부 R2DBC로 변환

### DIFF
--- a/purchase/.gitignore
+++ b/purchase/.gitignore
@@ -1,0 +1,3 @@
+.gradle
+.idea
+build

--- a/purchase/build.gradle
+++ b/purchase/build.gradle
@@ -1,12 +1,13 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.2.3'
-    id 'io.spring.dependency-management' version '1.1.4'
+    id 'org.springframework.boot' version '3.4.1'
+    id 'io.spring.dependency-management' version '1.1.7'
 }
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'
 repositories {
     mavenCentral()
+    maven { url 'https://repo.spring.io/release' }
 }
 java {
     sourceCompatibility = JavaVersion.VERSION_17
@@ -17,9 +18,15 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     annotationProcessor 'org.projectlombok:lombok'
-    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+//    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
-    implementation 'com.mysql:mysql-connector-j:8.2.0'
+//    implementation 'com.mysql:mysql-connector-j:8.2.0'
+    implementation 'org.springframework.boot:spring-boot-starter-data-r2dbc'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    runtimeOnly 'io.asyncer:r2dbc-mysql'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'io.projectreactor:reactor-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     implementation 'com.googlecode.json-simple:json-simple:1.1.1'
     implementation 'com.fasterxml.jackson.core:jackson-core:2.16.1'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'

--- a/purchase/src/main/java/org/example/controller/PurchaseController.java
+++ b/purchase/src/main/java/org/example/controller/PurchaseController.java
@@ -39,6 +39,7 @@ public class PurchaseController {
     }
 
 
+    //MSA 통신 용
     @PostMapping("/payments/complete")
     public ResponseEntity<PaymentsRes> saveOrder(@RequestBody List<OrderSaveRequest> orderSaveRequestList)
     {

--- a/purchase/src/main/java/org/example/dto/forbackend/OrderSaveRequest.java
+++ b/purchase/src/main/java/org/example/dto/forbackend/OrderSaveRequest.java
@@ -12,8 +12,8 @@ import java.time.LocalDate;
 public class OrderSaveRequest {
     private String seller ;
     private String consumer ;
-    private Long Post_id ;
-    private int Post_point;
+    private Long post_id;
+    private int post_point;
     private LocalDate purchase_at ;
 
 }

--- a/purchase/src/main/java/org/example/dto/forbackend/PaymentsReq.java
+++ b/purchase/src/main/java/org/example/dto/forbackend/PaymentsReq.java
@@ -12,7 +12,7 @@ import java.time.LocalDate;
 public class PaymentsReq {
     private String seller;
     private String consumer;
-    private int Post_point;
+    private int post_point;
     private Long Post_id;
     @DateTimeFormat(pattern = "yyyy-MM-dd")
     private LocalDate purchase_at;

--- a/purchase/src/main/java/org/example/entity/Order.java
+++ b/purchase/src/main/java/org/example/entity/Order.java
@@ -1,37 +1,45 @@
 package org.example.entity;
 
-import jakarta.persistence.*;
+//import jakarta.persistence.*;
+
+//import jakarta.persistence.GeneratedValue;
+//import jakarta.persistence.GenerationType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import lombok.*;
 import org.example.dto.forbackend.OrderSaveRequest;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Column;
+import org.springframework.data.relational.core.mapping.Table;
 
 import java.time.LocalDate;
 
 
 
 @Table(name = "orders")
-@Entity
+//@Entity
 @Getter
 @RequiredArgsConstructor
 public class Order {
 
     @Id
-    @Column(name = "order_id")
+    @Column("order_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long orderId;
 
-    @Column(name = "post_id")
+    @Column("post_id")
     private Long postId ;
 
-    @Column(name = "order_price")
+    @Column("order_price")
     private int orderPrice ;
 
-    @Column(name = "consumer_email")
+    @Column("consumer_email")
     private String consumerEmail ;
 
-    @Column(name = "seller_email")
+    @Column("seller_email")
     private String sellerEmail ;
 
-    @Column(name = "order_at")
+    @Column("order_at")
     private LocalDate orderAt;
 
     @Builder

--- a/purchase/src/main/java/org/example/repository/CreateandDeleteRepository.java
+++ b/purchase/src/main/java/org/example/repository/CreateandDeleteRepository.java
@@ -2,10 +2,12 @@ package org.example.repository;
 
 import org.springframework.data.repository.NoRepositoryBean;
 import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import reactor.core.publisher.Mono;
 
 
 @NoRepositoryBean
 public interface CreateandDeleteRepository<T,ID> extends Repository<T,ID> {
-    <S extends T> S save(S entity) ;
-    void delete(T entity);
+    <S extends T> Mono<S> save(S entity) ;
+    Mono<Void> delete(T entity);
 }

--- a/purchase/src/main/java/org/example/repository/OrderRepository.java
+++ b/purchase/src/main/java/org/example/repository/OrderRepository.java
@@ -1,7 +1,7 @@
 package org.example.repository;
 
 import org.example.entity.Order;
-import org.springframework.data.jpa.repository.JpaRepository;
+//import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository

--- a/purchase/src/main/java/org/example/repository/PaymentRepository.java
+++ b/purchase/src/main/java/org/example/repository/PaymentRepository.java
@@ -2,7 +2,7 @@ package org.example.repository;
 
 
 import org.example.entity.Payment;
-import org.springframework.data.jpa.repository.JpaRepository;
+//import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import org.springframework.stereotype.Service;
 

--- a/purchase/src/main/java/org/example/service/OrderService.java
+++ b/purchase/src/main/java/org/example/service/OrderService.java
@@ -1,33 +1,50 @@
 package org.example.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.example.dto.forbackend.OrderSaveRequest;
 import org.example.dto.forbackend.PaymentsRes;
 import org.example.entity.Order;
 import org.example.repository.OrderRepository;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
+import java.time.Duration;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class OrderService {
 
     private final OrderRepository orderRepository;
 
     public ResponseEntity<PaymentsRes> saveOrderRequstByMember(List<OrderSaveRequest> orderSaveRequestlist)
     {
-        for (OrderSaveRequest orderSaveRequest : orderSaveRequestlist) {
-            Order order = Order.builder()
-                    .orderPrice(orderSaveRequest.getPost_point())
-                    .orderAt(orderSaveRequest.getPurchase_at())
-                    .consumerEmail(orderSaveRequest.getConsumer())
-                    .sellerEmail(orderSaveRequest.getSeller())
-                    .postId(orderSaveRequest.getPost_id())
-                    .build();
-            orderRepository.save(order);
-        }
+        List<Order> orders = orderSaveRequestlist.stream()
+                .map(orderSaveRequest -> Order.builder()
+                        .orderPrice(orderSaveRequest.getPost_point())
+                        .orderAt(orderSaveRequest.getPurchase_at())
+                        .consumerEmail(orderSaveRequest.getConsumer())
+                        .sellerEmail(orderSaveRequest.getSeller())
+                        .postId(orderSaveRequest.getPost_id())
+                        .build())
+                .collect(Collectors.toList());
+
+        // 생성된 Order 객체들을 저장
+        // 다만 현재는 netty, 그러므로 .block()등의 메소드로 producer가 기다릴 수 없음
+        //현재 기다릴 수 있는 operator 측에서 작업하는 것으로 수정
+//        Flux.fromIterable(orders)
+//                .flatMap(orderRepository::save)
+//                .subscribe();
+
+        Flux.fromIterable(orders)
+                .flatMap(orderRepository::save)
+                .subscribe();
 
         PaymentsRes paymentsRes = PaymentsRes.builder()
                 .point(0)

--- a/purchase/src/main/java/org/example/service/PaymentService.java
+++ b/purchase/src/main/java/org/example/service/PaymentService.java
@@ -38,7 +38,7 @@ public class PaymentService {
 
     private final PaymentRepository paymentRepository;
 
-    @Value("${}")
+    @Value("${portonekey}")
     private String portoneKey;
 
 


### PR DESCRIPTION
학습을 진행하던 중, JPA 영역에서의 비동기 동작을 보장하면 다른 의존성으로 구현해야 함을 배워 활용해 보았습니다.

- 이전 프로젝트 요구사항 중 하나는, 통신 관련 응답 객체는 MONO 객체가 아닌 일반 RESPONSE ENTITY와 같은 형태로
**동기적인 응답을 하는 것 이었습니다.** 
- 이러한 제약조건에 맞추어 작업을 진행하려 하였습니다.
- .BLOCK()을 사용하려 했으나, NETTY를 활용한 방식이기 때문에 불가했습니다.
- 하여 OPERATOR 측에서의 작업 과정에 SAVE를 구현하여 , PRODUCER가 동기적인 응답을 하게 구현하였습니다. 

다음 작업은, 이전 비동기 저장 메소드 들의 R2DBC로 변화된 환경에서의 동작을 테스트하고,
로직을 CONSUMER와 PRODUCER의 명확한 책임이 있게 리팩토링 할 예정입니다.  